### PR TITLE
Add cargo-embed config

### DIFF
--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,45 @@
+[default.probe]
+protocol = "Swd"
+speed = 20000
+# If you only have one probe cargo embed will pick automatically
+# Otherwise: add your probe's VID/PID/serial to filter
+
+## rust-dap
+# usb_vid = "6666"
+# usb_pid = "4444"
+# serial = "test"
+
+
+[default.flashing]
+enabled = true
+restore_unwritten_bytes = false
+do_chip_erase = false
+disable_double_buffering = false
+preverify = false
+verify = false
+
+[default.reset]
+enabled = true
+halt_afterwards = false
+
+[default.general]
+chip = "RP2040"
+log_level = "WARN"
+# RP2040 does not support connect_under_reset
+connect_under_reset = false
+
+[default.rtt]
+enabled = true
+up_mode = "NoBlockSkip"
+up_channels = [
+    { channel = 0, mode = "BlockIfFull", format = "Defmt", show_location = true },
+]
+down_channels = [
+]
+timeout = 3000
+log_enabled = false
+log_path = "./logs"
+
+[default.gdb]
+enabled = false
+gdb_connection_string = "127.0.0.1:2345"


### PR DESCRIPTION
I thought I already added the config file for cargo-embed, but I had missed it.
This version is for cargo-embed 0.26 (not released yet)